### PR TITLE
fix: address php >= 8.4 implicitly nullable param deprecation

### DIFF
--- a/src/PsyshFacade.php
+++ b/src/PsyshFacade.php
@@ -48,7 +48,7 @@ final class PsyshFacade
         self::$shell::debug(array_merge(self::$shell->getScopeVariables(), $variables), $bind);
     }
 
-    public function setContainer(ContainerInterface $container = null): void
+    public function setContainer(?ContainerInterface $container = null): void
     {
         self::$container = $container;
     }


### PR DESCRIPTION
This addresses a deprecation caused by the implicitly nullable `$container` parameter for `PsyshFacade->setContainer` introduced in php versions >= 8.4.